### PR TITLE
Add Heidelberg (MQTT via wbec)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ If you want to contribute configurations to this repository please open a Pull R
 - [go-eCharger](#charger-go-echarger)
 - [go-eCharger (Cloud)](#charger-go-echarger-cloud)
 - [Heidelberg Energy Control (Modbus RTU)](#charger-heidelberg-energy-control-modbus-rtu)
+- [Heidelberg Energy Control (MQTT via wbec)](#charger-heidelberg-energy-control-wbec)
 - [i-CHARGE CION (Modbus RTU-over-TCP)](#charger-i-charge-cion-modbus-rtu-over-tcp)
 - [KEBA Connect](#charger-keba-connect)
 - [Mobile Charger Connect (Audi, Bentley, Porsche)](#charger-mobile-charger-connect-audi-bentley-porsche)
@@ -55,6 +56,7 @@ If you want to contribute configurations to this repository please open a Pull R
 - [Fronius Symo GEN24 Plus (Grid Meter)](#meter-fronius-symo-gen24-plus-grid-meter)
 - [Fronius Symo GEN24 Plus (PV Meter)](#meter-fronius-symo-gen24-plus-pv-meter)
 - [Generic](#meter-generic)
+- [Heidelberg Energy Control (MQTT via wbec)](#meter-heidelberg-energy-control-wbec)
 - [Huawei SUN2000-8KTL (PV Meter)](#meter-huawei-sun2000-8ktl-pv-meter)
 - [Kostal Energy Meter via inverter (Grid Meter)](#meter-kostal-energy-meter-via-inverter-grid-meter)
 - [Kostal Hybrid Inverter (Battery Meter)](#meter-kostal-hybrid-inverter-battery-meter)
@@ -330,6 +332,27 @@ If you want to contribute configurations to this repository please open a Pull R
       # ...
     - source: # L3 plugin type
       # ...
+```
+
+<a id="meter-heidelberg-energy-control-wbec"></a>
+#### Heidelberg Energy Control (MQTT via wbec)
+
+```yaml
+- type: custom
+  power:
+    source: mqtt
+    topic: wbec/lp/1/power
+  energy:
+    source: mqtt
+    topic: wbec/lp/1/energy
+  currents:
+    - source: mqtt
+      topic: wbec/lp/1/currL1
+    - source: mqtt
+      topic: wbec/lp/1/currL2
+    - source: mqtt
+      topic: wbec/lp/1/currL3
+# see also corresponding Charger
 ```
 
 <a id="meter-huawei-sun2000-8ktl-pv-meter"></a>
@@ -1158,6 +1181,26 @@ If you want to contribute configurations to this repository please open a Pull R
   baudrate: 19200
   comset: 8E1
   id: 1 # configurable (S2/DIP 1)
+```
+
+<a id="charger-heidelberg-energy-control-wbec"></a>
+#### Heidelberg Energy Control (MQTT via wbec)
+
+```yaml
+- type: custom
+  status:
+    source: mqtt
+    topic: wbec/lp/1/status
+  enabled:
+    source: mqtt
+    topic: wbec/lp/1/enabled
+  enable:
+    source: mqtt
+    topic: wbec/lp/1/enable
+  maxcurrent:
+    source: mqtt
+    topic: wbec/lp/1/maxcurrent
+# see also corresponding Charger
 ```
 
 <a id="charger-i-charge-cion-modbus-rtu-over-tcp"></a>

--- a/yaml/chargers/heidelberg-wbec.yaml
+++ b/yaml/chargers/heidelberg-wbec.yaml
@@ -1,0 +1,17 @@
+type: custom
+name: Heidelberg Energy Control (MQTT via wbec)
+sample: |
+  status:
+    source: mqtt
+    topic: wbec/lp/1/status
+  enabled:
+    source: mqtt
+    topic: wbec/lp/1/enabled
+  enable:
+    source: mqtt
+    topic: wbec/lp/1/enable
+  maxcurrent:
+    source: mqtt
+    topic: wbec/lp/1/maxcurrent
+
+# Additionally a meter is recommended (see Meters section)

--- a/yaml/meters/heidelberg-wbec.yaml
+++ b/yaml/meters/heidelberg-wbec.yaml
@@ -1,0 +1,18 @@
+type: custom
+name: Heidelberg Energy Control (MQTT via wbec)
+sample: |
+  power:
+    source: mqtt
+    topic: wbec/lp/1/power
+  energy:
+    source: mqtt
+    topic: wbec/lp/1/energy
+  currents:
+    - source: mqtt
+      topic: wbec/lp/1/currL1
+    - source: mqtt
+      topic: wbec/lp/1/currL2
+    - source: mqtt
+      topic: wbec/lp/1/currL3
+
+# See Chargers section for corresponding charger


### PR DESCRIPTION
Hi, 
hab eure Anregung aufgenommen: wbec 0.4.2 unterstützt jetzt die MQTT-Kommunikation mit EVCC, auch mit mehreren Ladepunkten und 0,1A-Genauigkeit.
Ich würde gerne die Beispielkonfiguration hier darstellen (readme.md). 
Ich habe auch mal entsprechende .yaml-Dateien erstellt, bin mir aber nicht sicher ob das in diesem Fall Sinn macht.